### PR TITLE
Check cookie banner display option for analytics integration

### DIFF
--- a/inc/consent/namespace.php
+++ b/inc/consent/namespace.php
@@ -8,6 +8,7 @@
 namespace Altis\Privacy\Consent;
 
 use Altis;
+use Altis\Consent;
 
 /**
  * Kick it off.
@@ -23,7 +24,7 @@ function bootstrap() {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_plugins', 1 );
 
 	// Ensure native analytics consent is enabled.
-	add_filter( 'altis.analytics.consent_enabled', '__return_true' );
+	add_filter( 'altis.analytics.consent_enabled', __NAMESPACE__ . '\\analytics_integration_enabled' );
 }
 
 /**
@@ -32,4 +33,13 @@ function bootstrap() {
 function load_plugins() {
 	require_once Altis\ROOT_DIR . '/vendor/altis/consent-api/plugin.php';
 	require_once Altis\ROOT_DIR . '/vendor/altis/consent/plugin.php';
+}
+
+/**
+ * Check if the consent banner is displayed to activate analytics integration.
+ *
+ * @return bool
+ */
+function analytics_integration_enabled() : bool {
+	return Consent\should_display_banner();
 }


### PR DESCRIPTION
This should have been the original check rather than defaulting to on.