### PR TITLE
Update the minimum PHP version to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Privacy module for Altis",
     "type": "package",
     "require": {
-        "php": ">=7.1",
+        "php": ">=8.2",
         "altis/consent": "~1.0.15"
     },
     "license": "GPL-3.0",


### PR DESCRIPTION
Update the minimum PHP version to that which Altis supports. This will allow dependabot to run successfully.

Addresses: humanmade/product-dev#1735