### PR TITLE
Update Dependabot for v24 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
   allow:
   - dependency-type: "direct"
   versioning-strategy: "increase"
+  target-branch: v24-branch
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: "direct"
+  versioning-strategy: "increase"
   target-branch: v23-branch
 - package-ecosystem: composer
   directory: "/"


### PR DESCRIPTION
This PR updates Dependabot configuration to add the v24 branch.
Addresses https://github.com/humanmade/product-dev/issues/1827