### PR TITLE
Update Dependabot for v26 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,17 @@ updates:
   allow:
   - dependency-type: "direct"
   versioning-strategy: "increase"
+  target-branch: v26-branch
+  commit-message:
+    prefix: "[v26-branch]"
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: "direct"
+  versioning-strategy: "increase"
   target-branch: v25-branch
   commit-message:
     prefix: "[v25-branch]"


### PR DESCRIPTION

This PR updates Dependabot configuration to add the v26 branch.